### PR TITLE
WIP: platform provisioning with ArgoCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,26 @@
-# assemble-platforms
+# Assemble Platforms
 This repository contains automation to install the assemble platform including supporting components. 
 
-## Helm Charts
+## Provisioning
 
-The charts folder contains helm charts that can be used to setup supporting applications used by the assemble platform.  
+The charts directory contains Helm charts that can be used to setup supporting applications used by the Assemble platform. These charts are referenced by ArgoCD applications and composed in a root application which is designed to install all platform dependencies.
 
-### Installing components using helm
+### Provision the platform using ArgoCD
+
+Provision the ArgoCD instance:
+
+```bash
+oc new-project assemble-argocd
+helm install gitops-operator charts/gitops-operator
+```
+
+Apply the root application:
+
+```bash
+oc apply -f root-application.yaml
+```
+
+### Provision individual components using the Helm CLI
 
 ```bash
 helm install $NAME -f my-values.yaml charts/$CHART_NAME

--- a/applications/pipelines-operator.yaml
+++ b/applications/pipelines-operator.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pipelines-operator
+  namespace: assemble-argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io  
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/halkyonio/assemble-platforms.git
+    targetRevision: HEAD
+    path: charts/pipelines-operator
+    helm:
+      values: | 
+        operator:
+          channel: latest
+          installPlanApproval: Automatic
+          name: openshift-pipelines-operator-rh
+          sourceName: redhat-operators
+          sourceNamespace: openshift-marketplace
+          startingCSV: openshift-pipelines-operator-rh.v1.8.0
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: openshift-operators
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true

--- a/root-application.yaml
+++ b/root-application.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root-application
+  namespace: assemble-argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/halkyonio/assemble-platforms.git
+    targetRevision: HEAD
+    path: applications
+    directory:
+      include: "*.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: assemble-argocd
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true       


### PR DESCRIPTION
This PR proposes a set of conventions for organizing Assemble platform components into a single root ArgoCD application. 

- Currently, there is only one platform component (openshift-pipelines-operator) besides ArgoCD itself which must be provisioned first and cannot be part of the root application. 
- As new platform components are added, Helm charts can be added to the `charts/` directory and referenced by ArgoCD Applications in the `applications/`.
- Applications in the `applications/` directory are automatically included by the root ArgoCD application located in the root directory of the repository.

Upcoming planned platform components that could be included as soon as charts are ready:
- Backstage
- Keycloak
- Postgres

See provisioning instructions included in the README to understand the provisioning steps from a user's perspective.