### PR TITLE
Chart for RHSSO backstage

### DIFF
--- a/charts/rhsso-backstage/.helmignore
+++ b/charts/rhsso-backstage/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/rhsso-backstage/Chart.yaml
+++ b/charts/rhsso-backstage/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: rhsso-backstage
+description: Deploys an instance of Red Hat Single Sign On (RHSSO) to support Backstage
+type: application
+version: 0.1.0

--- a/charts/rhsso-backstage/README.md
+++ b/charts/rhsso-backstage/README.md
@@ -1,0 +1,21 @@
+# rhsso-backstage
+
+Helm chart to Deploy an instance of Red Hat Single Sign on and configure the instance to support acting as an identity provider for Backstage
+
+## Installation
+
+Use the following steps to deploy the chart to an OpenShift cluster
+
+### Prerequisites
+
+1. Install the following Helm Charts
+    1. [RHSSO Operator](../operator/values-rhsso-operator.yaml)
+       1. Operator deployed to a namespace called `backstage`
+2. Create a [GitHub OAuth Application](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) within the desired GitHub organization
+
+### Deployment
+
+Execute the following command to install the chart to a an OpenShift cluster. Provide the clientId and clientSecret as parameters
+
+```shell
+helm upgrade -i rhsso-backstage . -n backstage --set keycloak.realm.identityProvider.clientId=<GITHUB_OAUTH_CLIENTID> --set keycloak.realm.identityProvider.clientSecret=<GITHUB_OAUTH_CLIENTSECRET> --set backstage.host=<BACKSTAGE_HOST>

--- a/charts/rhsso-backstage/README.md
+++ b/charts/rhsso-backstage/README.md
@@ -12,6 +12,7 @@ Use the following steps to deploy the chart to an OpenShift cluster
     1. [RHSSO Operator](../operator/values-rhsso-operator.yaml)
        1. Operator deployed to a namespace called `backstage`
 2. Create a [GitHub OAuth Application](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) within the desired GitHub organization
+    1. Configure the Redirect URL using the format: <https://<KEYCLOAK_HOST>/auth/realms/><REALM>/broker/github/endpoint
 
 ### Deployment
 

--- a/charts/rhsso-backstage/README.md
+++ b/charts/rhsso-backstage/README.md
@@ -12,7 +12,7 @@ Use the following steps to deploy the chart to an OpenShift cluster
     1. [RHSSO Operator](../operator/values-rhsso-operator.yaml)
        1. Operator deployed to a namespace called `backstage`
 2. Create a [GitHub OAuth Application](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) within the desired GitHub organization
-    1. Configure the Redirect URL using the format: <https://<KEYCLOAK_HOST>/auth/realms/><REALM>/broker/github/endpoint
+    1. Configure the Redirect URL using the format: `https://<KEYCLOAK_HOST>/auth/realms/<REALM>/broker/github/endpoint`
 
 ### Deployment
 
@@ -20,3 +20,4 @@ Execute the following command to install the chart to a an OpenShift cluster. Pr
 
 ```shell
 helm upgrade -i rhsso-backstage . -n backstage --set keycloak.realm.identityProvider.clientId=<GITHUB_OAUTH_CLIENTID> --set keycloak.realm.identityProvider.clientSecret=<GITHUB_OAUTH_CLIENTSECRET> --set backstage.host=<BACKSTAGE_HOST>
+```

--- a/charts/rhsso-backstage/templates/_helpers.tpl
+++ b/charts/rhsso-backstage/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rhsso-backstage.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rhsso-backstage.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rhsso-backstage.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rhsso-backstage.labels" -}}
+helm.sh/chart: {{ include "rhsso-backstage.chart" . }}
+{{ include "rhsso-backstage.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rhsso-backstage.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rhsso-backstage.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app: {{ include "rhsso-backstage.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rhsso-backstage.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rhsso-backstage.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the Redirect URI for OpenShift Authentication 
+*/}}
+{{- define "rhsso-backstage.clientSecretName" -}}
+{{ printf "keycloak-client-secret-%s" .Values.keycloak.client.name }}
+{{- end }}

--- a/charts/rhsso-backstage/templates/keycloak.yaml
+++ b/charts/rhsso-backstage/templates/keycloak.yaml
@@ -1,0 +1,12 @@
+apiVersion: keycloak.org/v1alpha1
+kind: Keycloak
+metadata:
+  name: {{ template "rhsso-backstage.name" . }}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    {{- include "rhsso-backstage.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.keycloak.instances }}
+  externalAccess:
+    enabled: true

--- a/charts/rhsso-backstage/templates/keycloakclient.yaml
+++ b/charts/rhsso-backstage/templates/keycloakclient.yaml
@@ -1,0 +1,22 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+  name: {{ .Values.keycloak.client.name }}
+  labels:
+    {{- include "rhsso-backstage.labels" . | nindent 4 }}
+spec:
+  realmSelector:
+    matchLabels:
+      {{- include "rhsso-backstage.selectorLabels" . | nindent 6 }}
+  client:
+    clientId: {{ .Values.keycloak.client.name }}
+    clientAuthenticatorType: client-secret
+    standardFlowEnabled: true
+    directAccessGrantsEnabled: true
+    implicitFlowEnabled: false
+    defaultClientScopes:
+      - profile
+      - email
+    consentRequired: false
+    redirectUris:
+      - {{ required "Backstage host is required" (printf "https://%s/oauth2/callback" .Values.backstage.host) }}

--- a/charts/rhsso-backstage/templates/keycloakrealm.yaml
+++ b/charts/rhsso-backstage/templates/keycloakrealm.yaml
@@ -1,0 +1,25 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  labels:
+    {{- include "rhsso-backstage.labels" . | nindent 4 }}
+  name: {{ .Values.keycloak.realm.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  realm:
+    id: {{ .Values.keycloak.realm.name }}
+    realm: {{ .Values.keycloak.realm.name }}
+    enabled: {{ .Values.keycloak.realm.enabled }}
+    displayName: {{ .Values.keycloak.realm.displayName }}
+{{- if .Values.keycloak.realm.identityProvider.enabled }}
+    identityProviders:
+      - alias: github
+        config:
+          clientId: {{ required "GitHub Identity Provider Client ID Must be Provided" .Values.keycloak.realm.identityProvider.clientId }}
+          clientSecret: {{ required "GitHub Identity Provider Client Secret Must be Provided" .Values.keycloak.realm.identityProvider.clientSecret }}
+        trustEmail: true
+        providerId: github
+{{- end }}
+  instanceSelector:
+    matchLabels:
+      {{- include "rhsso-backstage.selectorLabels" . | nindent 6 }}

--- a/charts/rhsso-backstage/values.yaml
+++ b/charts/rhsso-backstage/values.yaml
@@ -1,0 +1,21 @@
+keycloak:
+  instances: 1
+  hostname: ""
+  routeName: ""
+  realm:
+    name: backstage
+    enabled: true
+    displayName: Backstage Authentication Realm
+    identityProvider:
+      enabled: true
+      clientId: ""
+      clientSecret: ""
+  client:
+    name: backstage
+    secretName: openshift-client
+
+assemble:
+  group: assemble
+
+backstage:
+  host: ""


### PR DESCRIPTION
Helm chart to deploy an instance of RHSSO to support Backstage

Use the following instructions to deploy the chart to a namespace called `backstage`

```shell
helm upgrade -i rhsso-backstage . -n backstage --set keycloak.realm.identityProvider.clientId=<GITHUB_OAUTH_CLIENTID> --set keycloak.realm.identityProvider.clientSecret=<GITHUB_OAUTH_CLIENTSECRET> --set backstage.host=<BACKSTAGE_HOST>
```

Instructions can also be found in the README of the chart